### PR TITLE
examples: Externalize configuration values and allow for multiple env…

### DIFF
--- a/examples/bankLetter.js
+++ b/examples/bankLetter.js
@@ -6,18 +6,12 @@ const ebics = require('../index');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
-const bankName = 'Bank name'; // Change this to the bank name you're going to send the letter to.
-const languageCode = 'en'; // Currently 'de' and 'en' are valid values.
+const bankName = gConfig.bankName;
+const languageCode = gConfig.languageCode;
 const template = fs.readFileSync('../templates/ini_'+languageCode+'.hbs').toString();
 const letter = new ebics.BankLetter({ client, bankName, template });
 const bankLetterFile = path.join(os.homedir(), 'bankLetter_'+languageCode+'.html');

--- a/examples/config.js
+++ b/examples/config.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+
+const ebics = require('../index');
+const config = require('./config.json');
+var myArgs = process.argv.slice(2);
+//We can run this script with an argument. I.e. "testing" or "production" and it will load the corresponding configuration values for the corresponding environment from config.json
+const whichEnvironment = myArgs[0].trim().toLowerCase();
+const defaultConfig = config.testing;
+//We default back to test in case whichEnvironment argument is not passed while running the script, so we don't accidentally end up making changes in production.
+const environment = whichEnvironment || 'testing';
+const environmentConfig = config[environment];
+if (!environmentConfig) {
+	console.log("ERROR! Could not find configuration for \""+whichEnvironment+"\" using configuration for \"testing\" instead");
+}
+
+global.gFinalConfig = _.merge(defaultConfig, environmentConfig);
+
+global.gClient = new ebics.Client({
+	url: gFinalConfig.serverAddress,
+	partnerId: gFinalConfig.partnerId,
+	userId: gFinalConfig.userId,
+	hostId: gFinalConfig.hostId,
+	passphrase: gFinalConfig.passphrase, // keys-test will be encrypted with this passphrase
+	keyStorage: ebics.fsKeysStorage(gFinalConfig.keyStorage),
+});

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,0 +1,42 @@
+{
+    "testing": {
+        "serverAddress": "https://ebics-test.server",
+        "partnerId": "EBICS ParnerID Test",
+        "userId": "MyUserIdTest",
+        "hostId": "MyHostIdTest",
+        "passphrase": "MyPasswordTest",
+        "keyStorage": "./keys-test",
+        "bankName":"Test Bank",
+        "languageCode":"en"
+    },
+    "development": {
+        "serverAddress": "https://ebics-development.server",
+        "partnerId": "EBICS ParnerID Development",
+        "userId": "MyUserIdDevelopment",
+        "hostId": "MyHostIdDevelopment",
+        "passphrase": "MyPasswordDevelopment",
+        "keyStorage": "./keys-development",
+        "bankName":"Development Bank",
+        "languageCode":"en"
+    },
+    "staging": {
+        "serverAddress": "https://ebics-staging.server",
+        "partnerId": "EBICS ParnerID Staging",
+        "userId": "MyUserIdStaging",
+        "hostId": "MyHostIdStaging",
+        "passphrase": "MyPasswordStaging",
+        "keyStorage": "./keys-staging",
+        "bankName":"Staging Bank",
+        "languageCode":"en"
+    },
+    "production": {
+        "serverAddress": "https://ebics.server",
+        "partnerId": "EBICS ParnerID Production",
+        "userId": "MyUserIdProduction",
+        "hostId": "MyHostIdProduction",
+        "passphrase": "MyPasswordProduction",
+        "keyStorage": "./keys-prod",
+        "bankName":"Production Bank",
+        "languageCode":"en"
+    }
+}

--- a/examples/initialize.js
+++ b/examples/initialize.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: 'PARTNER',
-	userId: 'USER',
-	hostId: 'HOST',
-	passphrase: 'test', // keys-test will be encrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // New keys will be generated and saved in ./keys-test
 client.send(ebics.Orders.INI)

--- a/examples/save-bank-keys.js
+++ b/examples/save-bank-keys.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // Client keys must be already generated and send by letter.
 // The bank should have enabled the user

--- a/examples/send-c52-order.js
+++ b/examples/send-c52-order.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // The bank keys must have been already saved
 client.send(ebics.Orders.C52(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'

--- a/examples/send-c53-order.js
+++ b/examples/send-c53-order.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // The bank keys must have been already saved
 client.send(ebics.Orders.C53(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'

--- a/examples/send-dki-order.js
+++ b/examples/send-dki-order.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // The bank keys must have been already saved
 client.send(ebics.Orders.DKI(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'

--- a/examples/send-hkd-order.js
+++ b/examples/send-hkd-order.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // The bank keys must have been already saved
 client.send(ebics.Orders.HKD)

--- a/examples/send-htd-order.js
+++ b/examples/send-htd-order.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // The bank keys must have been already saved
 client.send(ebics.Orders.HTD)

--- a/examples/send-sta-order.js
+++ b/examples/send-sta-order.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // The bank keys must have been already saved
 client.send(ebics.Orders.STA(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'

--- a/examples/send-vmk-order.js
+++ b/examples/send-vmk-order.js
@@ -3,15 +3,9 @@
 'use strict';
 
 const ebics = require('../index');
+const configjs = require('./config.js');
 
-const client = new ebics.Client({
-	url: 'https://ebics.server',
-	partnerId: '',
-	userId: '',
-	hostId: '',
-	passphrase: 'test', // keys-test will be decrypted with this passphrase
-	keyStorage: ebics.fsKeysStorage('./keys-test'),
-});
+const client = gClient;
 
 // The bank keys must have been already saved
 client.send(ebics.Orders.VMK(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"auto-changelog": "^1.16.2",
 		"handlebars": "^4.5.3",
 		"js2xmlparser": "^4.0.0",
+		"lodash":"^4.17.15",
 		"node-forge": "^0.9.1",
 		"request": "^2.88.0",
 		"uuid": "^3.3.3",


### PR DESCRIPTION
…ironments

In order to more easily manage testing of various order types as well as production, development etc. environments, externalize this config values.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>