### PR TITLE
Wait until the keys are generated

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -104,7 +104,7 @@ module.exports = class Client {
 
 	async initialization(order) {
 		const keys = await this.keys();
-		if (keys === null) this._generateKeys();
+		if (keys === null) await this._generateKeys();
 
 		if (this.tracesStorage)
 			this.tracesStorage.new().ofType('ORDER.INI');
@@ -223,10 +223,10 @@ module.exports = class Client {
 		}
 	}
 
-	_generateKeys() {
+	async _generateKeys() {
 		const keysObject = Keys.generate();
 
-		this._writeKeys(keysObject);
+		await this._writeKeys(keysObject);
 	}
 
 	async setBankKeys(bankKeys) {


### PR DESCRIPTION
The initialization method should wait until the key file is written because other methods could use the keys-method after initialization.