### PR TITLE
fix high severity vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1991,9 +1991,9 @@
 			"dev": true
 		},
 		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
 		},
 		"inquirer": {
@@ -2767,15 +2767,15 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
 			"dev": true
 		},
 		"node-forge": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-			"integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
 		},
 		"node-pre-gyp": {
 			"version": "0.11.0",
@@ -4346,9 +4346,9 @@
 			}
 		},
 		"xml-crypto": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-1.5.3.tgz",
-			"integrity": "sha512-uHkmpUtX15xExe5iimPmakAZN+6CqIvjmaJTy4FwqGzaTjrKRBNeqMh8zGEzVNgW0dk6beFYpyQSgqV/J6C5xA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.0.0.tgz",
+			"integrity": "sha512-/a04qr7RpONRZHOxROZ6iIHItdsQQjN3sj8lJkYDDss8tAkEaAs0VrFjb3tlhmS5snQru5lTs9/5ISSMdPDHlg==",
 			"requires": {
 				"xmldom": "0.1.27",
 				"xpath": "0.0.27"

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
 	"dependencies": {
 		"handlebars": "^4.7.6",
 		"js2xmlparser": "^4.0.1",
-		"node-forge": "^0.9.1",
+		"node-forge": "^0.10.0",
 		"request": "^2.88.2",
 		"uuid": "^8.0.0",
-		"xml-crypto": "^1.5.3",
+		"xml-crypto": "^2.0.0",
 		"xmldom": "^0.3.0",
 		"xpath": "0.0.27"
 	},


### PR DESCRIPTION
node-forge and xml-crypto have high severity vulnerabilities. This PR updates the dependencies to the fixed versions. Tested by sending a CCT order to an ebics server. "npm run test" reports no errors.