### PR TITLE
Add sample code for zipped CAMT statements

### DIFF
--- a/examples/send-c52-order-zipped.js
+++ b/examples/send-c52-order-zipped.js
@@ -1,0 +1,28 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+
+const client = require('./getClient')();
+const { Orders } = require('../index');
+
+// The bank keys must have been already saved
+client.send(Orders.C52(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'
+	.then((resp) => {
+		console.log('Response for C52 order %j', resp);
+		if (resp.technicalCode !== '000000')
+			throw new Error('Something went wrong');
+
+		// Parsing and processing the CAMT052 file should happen somewhere here, ideally after saving it to disk
+		const data = Buffer.from(resp.orderData);
+		let distPath = "CAMT052.zip"; 
+		const dstZip = fs.createWriteStream(distPath); 
+		dstZip.write(data); 
+		dstZip.end();
+	})
+
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});

--- a/examples/send-c53-order-zipped.js
+++ b/examples/send-c53-order-zipped.js
@@ -1,0 +1,28 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+
+const client = require('./getClient')();
+const { Orders } = require('../index');
+
+// The bank keys must have been already saved
+client.send(Orders.C53(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'
+	.then((resp) => {
+		console.log('Response for C53 order %j', resp);
+		if (resp.technicalCode !== '000000')
+			throw new Error('Something went wrong');
+
+		// Parsing and processing the CAMT053 file should happen somewhere here, ideally after saving it to disk
+		const data = Buffer.from(resp.orderData);
+		let distPath = "CAMT053.zip"; 
+		const dstZip = fs.createWriteStream(distPath); 
+		dstZip.write(data); 
+		dstZip.end();
+	})
+
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});


### PR DESCRIPTION
Some banks provide zipped CAMT statements, add some example code on how to write these to a file.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>