### PR TITLE
Add support for Bank GPB AO (Gazprombank Russia)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The client is currently tested and verified to work with the following banks:
 * [Raiffeisen Schweiz](https://www.raiffeisen.ch/rch/de.html)
 * [BW Bank](https://www.bw-bank.de/de/home.html)
 * [Bank GPB International S.A.](https://gazprombank.lu/e-banking)
+* [Bank GPB AO](https://gazprombank.ru/)
 
 
 ## Inspiration

--- a/examples/send-g02-order-zipped.js
+++ b/examples/send-g02-order-zipped.js
@@ -1,0 +1,28 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+
+const client = require('./getClient')();
+const { Orders } = require('../index');
+
+// The bank keys must have been already saved
+client.send(Orders.G02(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'
+	.then((resp) => {
+		console.log('Response for G02 order %j', resp);
+		if (resp.technicalCode !== '000000')
+			throw new Error('Something went wrong');
+
+		// Parsing and processing the G02 Pain.002.001.06 file should happen somewhere here, ideally after saving it to disk
+		const data = Buffer.from(resp.orderData); 
+		let distPath = "G02.zip"; 
+		const dstZip = fs.createWriteStream(distPath); 
+		dstZip.write(data); 
+		dstZip.end();
+	})
+
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});

--- a/examples/send-g1r-order.js
+++ b/examples/send-g1r-order.js
@@ -1,0 +1,20 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+
+const client = require('./getClient')();
+const { Orders } = require('../index');
+
+// The bank keys must have been already saved
+const paymentFile = fs.readFileSync('RUB_PAYMENT.xml').toString();
+
+client.send(Orders.G1R(paymentFile))
+	.then((resp) => {
+		console.log('Response for G1R order %j', resp);
+	})
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});

--- a/examples/send-g1v-order.js
+++ b/examples/send-g1v-order.js
@@ -1,0 +1,20 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+
+const client = require('./getClient')();
+const { Orders } = require('../index');
+
+// The bank keys must have been already saved
+const paymentFile = fs.readFileSync('FCY_PAYMENT.xml').toString();
+
+client.send(Orders.G1V(paymentFile))
+	.then((resp) => {
+		console.log('Response for G1V order %j', resp);
+	})
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});

--- a/examples/send-g52-order-zipped.js
+++ b/examples/send-g52-order-zipped.js
@@ -1,0 +1,28 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+
+const client = require('./getClient')();
+const { Orders } = require('../index');
+
+// The bank keys must have been already saved
+client.send(Orders.G52(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'
+	.then((resp) => {
+		console.log('Response for G52 order %j', resp);
+		if (resp.technicalCode !== '000000')
+			throw new Error('Something went wrong');
+
+		// Parsing and processing the CAMT052 file should happen somewhere here, ideally after saving it to disk
+		const data = Buffer.from(resp.orderData);
+		let distPath = "CAMT052-G52.zip"; 
+		const dstZip = fs.createWriteStream(distPath); 
+		dstZip.write(data); 
+		dstZip.end();
+	})
+
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});

--- a/examples/send-g53-order-zipped.js
+++ b/examples/send-g53-order-zipped.js
@@ -1,0 +1,28 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+
+const client = require('./getClient')();
+const { Orders } = require('../index');
+
+// The bank keys must have been already saved
+client.send(Orders.G53(null, null)) // startDate 'YYYY-MM-DD', endDate 'YYYY-MM-DD'
+	.then((resp) => {
+		console.log('Response for G53 order %j', resp);
+		if (resp.technicalCode !== '000000')
+			throw new Error('Something went wrong');
+
+		// Parsing and processing the CAMT053 file should happen somewhere here, ideally after saving it to disk
+		const data = Buffer.from(resp.orderData);
+		let distPath = "CAMT053-G53.zip"; 
+		const dstZip = fs.createWriteStream(distPath); 
+		dstZip.write(data); 
+		dstZip.end();
+	})
+
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});

--- a/lib/predefinedOrders/G02.js
+++ b/lib/predefinedOrders/G02.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const utils = require('../utils');
+
+module.exports = (start = null, end = null) => ({
+	version: 'h004',
+	orderDetails: {
+		OrderType: 'G02',
+		OrderAttribute: 'DZHNN',
+		StandardOrderParams: utils.dateRange(start, end),
+	},
+	operation: 'download',
+});

--- a/lib/predefinedOrders/G1R.js
+++ b/lib/predefinedOrders/G1R.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = document => ({
+	version: 'h004',
+	orderDetails: { OrderType: 'G1R', OrderAttribute: 'DZHNN', StandardOrderParams: {} },
+	operation: 'upload',
+	document,
+});

--- a/lib/predefinedOrders/G1V.js
+++ b/lib/predefinedOrders/G1V.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = document => ({
+	version: 'h004',
+	orderDetails: { OrderType: 'G1V', OrderAttribute: 'DZHNN', StandardOrderParams: {} },
+	operation: 'upload',
+	document,
+});

--- a/lib/predefinedOrders/G52.js
+++ b/lib/predefinedOrders/G52.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const utils = require('../utils');
+
+module.exports = (start = null, end = null) => ({
+	version: 'h004',
+	orderDetails: {
+		OrderType: 'G52',
+		OrderAttribute: 'DZHNN',
+		StandardOrderParams: utils.dateRange(start, end),
+	},
+	operation: 'download',
+});

--- a/lib/predefinedOrders/G53.js
+++ b/lib/predefinedOrders/G53.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const utils = require('../utils');
+
+module.exports = (start = null, end = null) => ({
+	version: 'h004',
+	orderDetails: {
+		OrderType: 'G53',
+		OrderAttribute: 'DZHNN',
+		StandardOrderParams: utils.dateRange(start, end),
+	},
+	operation: 'download',
+});

--- a/lib/predefinedOrders/index.js
+++ b/lib/predefinedOrders/index.js
@@ -14,6 +14,8 @@ const CCS = require('./CCS');
 const XE3 = require('./XE3');
 const XCT = require('./XCT');
 const XG1 = require('./XG1');
+const G1V = require('./G1V');
+const G1R = require('./G1R');
 
 const STA = require('./STA');
 const VMK = require('./VMK');
@@ -27,6 +29,9 @@ const Z53 = require('./Z53');
 const DKI = require('./DKI');
 const C52 = require('./C52');
 const C53 = require('./C53');
+const G52 = require('./G52');
+const G53 = require('./G53');
+const G02 = require('./G02');
 
 module.exports = {
 	INI,
@@ -44,6 +49,8 @@ module.exports = {
 	XE3,
 	XCT,
 	XG1,
+	G1V,
+	G1R,
 
 	STA,
 	VMK,
@@ -56,4 +63,7 @@ module.exports = {
 	DKI,
 	C52,
 	C53,
+	G52,
+	G53,
+	G02,
 };


### PR DESCRIPTION
Add custom order types (G02, G52, G53, G1R and G1V) and examples for Bank GPB AO (Gazprombank Russia).

Pain.001.001.06 (RUB) - G1R
Pain.001.001.06 (FCY/FX/RLS) - G1V
Pain.002.001.06 - G02
Camt.052.001.05 - G52
Camt.053.001.05 - G53

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>