### PR TITLE
Cryto.js: Nasty workaround for incorrect signature (257 vs 256) and h…

### DIFF
--- a/lib/crypto/Crypto.js
+++ b/lib/crypto/Crypto.js
@@ -78,13 +78,8 @@ module.exports = class Crypto {
 		{
 			console.log("hex string of key starts with \"00\" and is 514 bytes long, fixing it to be 512 bytes long by stripping leading \"00\"");
 			hexString = hexString.substr(2);
-			var base64String = Buffer.from(hexString, 'hex').toString('base64')
-			return base64String;
 		}
-		else
-		{
-			return (modPow(base, power, mod)).toBEBuffer().toString('base64');
-		}
+		return Buffer.from(hexString, 'hex').toString('base64');
 	}
 
 	static pad(d) {

--- a/lib/crypto/Crypto.js
+++ b/lib/crypto/Crypto.js
@@ -72,7 +72,19 @@ module.exports = class Crypto {
 		const power = new BigNumber(key.d());
 		const mod = new BigNumber(key.n());
 
-		return (modPow(base, power, mod)).toBEBuffer().toString('base64');
+		//Somehow sometimes we have a 514 byte hex key that starts with "00". In that case use only the last 512 bytes
+		var hexString = modPow(base, power, mod).toBEBuffer().toString('hex');
+		if(hexString.substr(0,2) === "00" && hexString.length == 514) 
+		{
+			console.log("hex string of key starts with \"00\" and is 514 bytes long, fixing it to be 512 bytes long by stripping leading \"00\"");
+			hexString = hexString.substr(2);
+			var base64String = Buffer.from(hexString, 'hex').toString('base64')
+			return base64String;
+		}
+		else
+		{
+			return (modPow(base, power, mod)).toBEBuffer().toString('base64');
+		}
 	}
 
 	static pad(d) {


### PR DESCRIPTION
…ex key length (514 vs 512)

For some unknown reason, the signature gets a length of 257 bytes instead of 256 bytes, and the length of the hex value is 514 bytes instead of 512 bytes in some edge cases. When trying with the same file, it seems to happen once every 3-4 tries.

This works around it until a proper fix is implemented. The bug seems to be caused by https://github.com/node-ebics/node-ebics-client/blob/master/lib/crypto/Crypto.js#L71 somehow.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>