### PR TITLE
Add additional bank configuration items

### DIFF
--- a/examples/bankLetter.js
+++ b/examples/bankLetter.js
@@ -9,10 +9,9 @@ const os = require('os');
 
 const config = require('./loadConfig')();
 const client = require('./getClient')(config);
-const bankName = config.bankName;
-const languageCode = config.languageCode;
-const template = fs.readFileSync('../templates/ini_'+config.languageCode+'.hbs', { encoding: 'utf8 '});
-const bankLetterFile = path.join(os.homedir(), 'bankLetter_'+languageCode+'.html');
+const bankName = client.bankName;
+const template = fs.readFileSync("../templates/ini_"+client.languageCode+".hbs", { encoding: 'utf8'});
+const bankLetterFile = path.join("./", "bankLetter_"+client.bankShortName+"_"+client.languageCode+".html");
 
 const letter = new ebics.BankLetter({ client, bankName, template });
 

--- a/examples/config/config.json
+++ b/examples/config/config.json
@@ -5,6 +5,8 @@
 	"hostId": "MyHostIdTest",
 	"passphrase": "MyPasswordTest",
 	"keyStoragePath": "./keys-test",
-	"bankName":"Test Bank",
-	"languageCode":"en"
+	"bankName":"Test Bank Full Name",
+	"bankShortName":"TESTBANKSHORT",
+	"languageCode":"en",
+	"storageLocation":"\\\\myserver\\Share\\Folder\\BankName\\Test\\"
 }

--- a/examples/config/config.production.testbank.json
+++ b/examples/config/config.production.testbank.json
@@ -5,6 +5,8 @@
 	"hostId": "MyHostIdProduction",
 	"passphrase": "MyPasswordProduction",
 	"keyStoragePath": "./keys-prod",
-	"bankName":"Production Bank",
-	"languageCode":"en"
+	"bankName":"Production Bank Full Name",
+	"bankShortName":"PRODBANKSHORT",
+	"languageCode":"en",
+	"storageLocation":"\\\\myserver\\Share\\Folder\\BankName\\Production\\"
 }

--- a/examples/config/config.production.testbank.testentity.json
+++ b/examples/config/config.production.testbank.testentity.json
@@ -1,0 +1,12 @@
+{
+	"url": "https://ebics.server",
+	"partnerId": "EBICS ParnerID Production",
+	"userId": "MyUserIdProduction",
+	"hostId": "MyHostIdProduction",
+	"passphrase": "MyPasswordProduction",
+	"keyStoragePath": "./keys-prod",
+	"bankName":"Production Bank Full Name",
+	"bankShortName":"PRODBANKSHORT",
+	"languageCode":"en",
+	"storageLocation":"\\\\myserver\\Share\\Folder\\BankName\\Production\\"
+}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -46,6 +46,10 @@ const stringifyKeys = (keys) => {
  * @property {string} passphrase - passphrase for keys encryption
  * @property {KeyStorage} keyStorage - keyStorage implementation
  * @property {object} [tracesStorage] - traces (logs) storage implementation
+ * @property {string} bankName - Full name of the bank to be used in the bank INI letters.
+ * @property {string} bankShortName - Short name of the bank to be used in folders, filenames etc.
+ * @property {string} languageCode - Language code to be used in the bank INI letters ("de", "en" and "fr" are currently supported).
+ * @property {string} storageLocation - Location where to store the files that are downloaded. This can be a network share for example.
  */
 
 
@@ -62,6 +66,10 @@ module.exports = class Client {
 		passphrase,
 		keyStorage,
 		tracesStorage,
+		bankName,
+		bankShortName,
+		languageCode,
+		storageLocation,
 	}) {
 		if (!url)
 			throw new Error('EBICS URL is required');
@@ -83,7 +91,11 @@ module.exports = class Client {
 		this.hostId = hostId;
 		this.keyStorage = keyStorage;
 		this.keyEncryptor = defaultKeyEncryptor({ passphrase });
-		this.tracesStorage = tracesStorage || null;
+		this.tracesStorage = tracesStorage || null; 
+		this.bankName = bankName || "Dummy Bank Full Name",
+		this.bankShortName = bankShortName || "BANKSHORTCODE",
+		this.languageCode = languageCode || "en",
+		this.storageLocation = storageLocation || null,
 	}
 
 	async send(order) {

--- a/templates/ini_fr.hbs
+++ b/templates/ini_fr.hbs
@@ -1,0 +1,164 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<meta charset="UTF-8" />
+	<title>EBICS ini</title>
+</head>
+
+<body>
+	<div>
+		<h2>Lettre d'initialisation pour clés électroniques bancaires (INI)</h2>
+		<table>
+			<tr>
+				<td>Date</td>
+				<td>{{ today }}</td>
+			</tr>
+			<tr>
+				<td>Heure</td>
+				<td>{{ now }}</td>
+			</tr>
+			<tr>
+				<td>Banque</td>
+				<td>{{ bankName }}</td>
+			</tr>
+			<tr>
+				<td>ID Utilisateur</td>
+				<td>{{ userId }}</td>
+			</tr>
+			<tr>
+				<td>ID Partenaire</td>
+				<td>{{ partnerId }}</td>
+			</tr>
+		</table>
+		<p>Clé publique (Public Key) pour la signature électronique (A006)</p>
+		<p>Exposant ({{ keyExponentBits A006 }} Bit):</p>
+		<p>
+			<code>{{ keyExponent A006 }}</code>
+		</p>
+		<p>Modulo ({{ keyModulusBits A006 }} Bit):</p>
+		<p>
+			<code>{{ keyModulus A006 }}</code>
+		</p>
+		<p>Hash (SHA-256):</p>
+		<p>
+			<code>{{ sha256 A006 }}</code>
+		</p>
+		<p>Je confirme par la présente la clé publique ci-dessus pour ma signature électronique.</p>
+		<br/>
+		<br/>
+		<br/>
+		<br/>
+		<table>
+			<tr>
+				<td>_________________________</td>
+				<td>_________________________</td>
+				<td>_________________________</td>
+			</tr>
+			<tr>
+				<td>Lieu/Date</td>
+				<td>Nom/Entreprise</td>
+				<td>Signature</td>
+			</tr>
+		</table>
+	</div>
+	<div style="page-break-after:always"></div>
+	<h2>Lettre d'initialisation pour clés électroniques bancaires (HIA) - Page 1/2</h2>
+	<table>
+		<tr>
+			<td>Date</td>
+			<td>{{ today }}</td>
+		</tr>
+		<tr>
+			<td>Heure</td>
+			<td>{{ now }}</td>
+		</tr>
+		<tr>
+			<td>Banque</td>
+			<td>{{ bankName }}</td>
+		</tr>
+		<tr>
+			<td>ID Utilisateur</td>
+			<td>{{ userId }}</td>
+		</tr>
+		<tr>
+			<td>ID Partenaire</td>
+			<td>{{ partnerId }}</td>
+		</tr>
+	</table>
+	<div>
+		<p>Clé d'identification publique (X002)</p>
+		<p>Exposant ({{ keyExponentBits X002 }} Bit):</p>
+		<p>
+			<code>{{ keyExponent X002 }}</code>
+		</p>
+		<p>Modulo ({{ keyModulusBits X002 }} Bit):</p>
+		<p>
+			<code>{{ keyModulus X002 }}</code>
+		</p>
+		<p>Hash (SHA-256):</p>
+		<p>
+			<code>{{ sha256 X002 }}</code>
+		</p>
+		<p>Suite à la page 2 ...</p>
+		<div style="page-break-after:always"></div>
+		<h2>Lettre d'initialisation pour clés électroniques bancaires (HIA) - Page 2/2</h2>
+	<table>
+		<tr>
+			<td>Date</td>
+			<td>{{ today }}</td>
+		</tr>
+		<tr>
+			<td>Heure</td>
+			<td>{{ now }}</td>
+		</tr>
+		<tr>
+			<td>Banque</td>
+			<td>{{ bankName }}</td>
+		</tr>
+		<tr>
+			<td>ID Utilisateur</td>
+			<td>{{ userId }}</td>
+		</tr>
+		<tr>
+			<td>ID Partenaire</td>
+			<td>{{ partnerId }}</td>
+		</tr>
+	</table>
+	</div>
+	<div>
+		<p>Clé de chiffrement publique (E002)</p>
+		<p>Exposant ({{ keyExponentBits E002 }} Bit):</p>
+		<p>
+			<code>{{ keyExponent E002 }}</code>
+		</p>
+		<p>Modulo ({{ keyModulusBits E002 }} Bit):</p>
+		<p>
+			<code>{{ keyModulus E002 }}</code>
+		</p>
+		<p>Hash (SHA-256):</p>
+		<p>
+			<code>{{ sha256 E002 }}</code>
+		</p>
+		<p>Je confirme par la présente les clés publiques ci-dessus.</p>
+		<br/>
+		<br/>
+		<br/>
+		<br/>
+		<table>
+			<tr>
+				<td>_________________________</td>
+				<td>_________________________</td>
+				<td>_________________________</td>
+			</tr>
+			<tr>
+				<td>Lieu/Date</td>
+				<td>Nom/Entreprise</td>
+				<td>Signature</td>
+			</tr>
+		</table>
+	</div>
+</body>
+
+</html>


### PR DESCRIPTION
For a prettier generation of bank letters and other bits used in examples:

* Added a French template based on implementation guide with French example from ABACUS Research SA.

Expand the bank config to include:

* "bankFullName" used in the INI letter's which are sent to the bank.
* "bankShortName" used in the filename for the generated letters and in other places if needed.
* "languageCode" used for determining which template to use for the bank (currently "en" and "de" are supported).
* "storageLocation" can be used to specify a local or network path where to store downloaded files.

* In bankLetter.js: Use the current script folder as output for the bank's letter in HTML format instead of the user/os homedir folder.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>