### PR TITLE
Fix response parsing

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -224,7 +224,7 @@ module.exports = class Client {
 				(err, res, data) => {
 					if (err) reject(err);
 
-					const ebicsResponse = response.version(version)(data, keys);
+					const ebicsResponse = response.version(version)(data.toString('utf-8'), keys);
 
 					if (this.tracesStorage)
 						this.tracesStorage


### PR DESCRIPTION
Regression introduced in v4.0.0 with this commit: https://github.com/node-ebics/node-ebics-client/commit/b6b27516d5854b38dcdbe56f23967001f844e631

`rock-req` returns a `Buffer`, not a string as response data.