### PR TITLE
Improve readme, update xml-crypto, fix ci, replace deprecated crypto methods and make add compatibility with NodeJS 22. 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 18, 19, 20 ]
+        node: [ 18, 20, 22 ]
     name: Node.js ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 <a href='https://coveralls.io/github/eCollect/node-ebics-client?branch=master' title="Coverage Status"><img src='https://coveralls.io/repos/github/eCollect/node-ebics-client/badge.svg?branch=master' alt='Coverage Status' /></a>
 </p>
 
-Pure node.js ( >=8 ) implementation of [EBICS](https://en.wikipedia.org/wiki/Electronic_Banking_Internet_Communication_Standard) ( Electronic Banking Internet Communication ).
+Pure node.js (>= 16) implementation of [EBICS](https://en.wikipedia.org/wiki/Electronic_Banking_Internet_Communication_Standard) (Electronic Banking Internet Communication).
 
-The client is aimed to be 100% [ISO 20022](https://www.iso20022.org) compliant, and supports the complete initializations process ( INI, HIA, HPB orders ) and HTML letter generation.
+The client is aimed to be 100% [ISO 20022](https://www.iso20022.org) compliant, and supports the complete initializations process (INI, HIA, HPB orders) and HTML letter generation.
 
 
 ## Supported Banks
@@ -41,4 +41,3 @@ The basic concept of this library was inspired by the [EPICS](https://github.com
 
 Copyright: Dimitar Nanov, 2019-2022.  
 Licensed under the [MIT](LICENSE) license.
-

--- a/README.md
+++ b/README.md
@@ -15,27 +15,53 @@
 <a href='https://coveralls.io/github/eCollect/node-ebics-client?branch=master' title="Coverage Status"><img src='https://coveralls.io/repos/github/eCollect/node-ebics-client/badge.svg?branch=master' alt='Coverage Status' /></a>
 </p>
 
-Pure node.js (>= 16) implementation of [EBICS](https://en.wikipedia.org/wiki/Electronic_Banking_Internet_Communication_Standard) (Electronic Banking Internet Communication).
+Pure Node.js (>= 16) implementation of [EBICS](https://en.wikipedia.org/wiki/Electronic_Banking_Internet_Communication_Standard) (Electronic Banking Internet Communication).
 
 The client is aimed to be 100% [ISO 20022](https://www.iso20022.org) compliant, and supports the complete initializations process (INI, HIA, HPB orders) and HTML letter generation.
 
+## Usage
+
+For examples on how to use this library, take a look at the [examples](https://github.com/node-ebics/node-ebics-client/tree/master/examples).
+
+### A note on recent Node.js versions
+
+The latest Node.js versions don't support `RSA_PKCS1_PADDING` for private decryption for security reasons, throwing an error like _TypeError: RSA_PKCS1_PADDING is no longer supported for private decryption, this can be reverted with --security-revert=CVE-2023-46809_.
+
+EBICS requires this mode, so in order for this library to work, add the following parameter when starting Node.js: `--security-revert=CVE-2023-46809`
+
+### Initialization
+
+1. Create a configuration (see [example configs](https://github.com/node-ebics/node-ebics-client/tree/master/examples/config)) with the EBICS credentials you received from your bank and name it in this schema: `config.<environment>.<bank>[.<entity>].json` (the entity is optional).
+
+    - The fields `url`, `partnerId`, `userId`, `hostId` are provided by your bank.
+    - The `passphrase` is used to encrypt the keys file, which will be stored at the `storageLocation`.
+    - The `bankName` and `bankShortName` are used internally for creating files and identifying the bank to you.
+    - The `languageCode` is used when creating the Initialization Letter and can be either `de`, `en`, or `fr`.
+    - You can chose any environment, bank and, optionally, entity name. Entities are useful if you have multiple EBICS users for the same bank account.
+
+2. Run `node examples/initialize.js <environment> <bank> [entity]` to generate your key pair and perform the INI and HIA orders (ie. send the public keys to your bank)  
+   The generated keys are stored in the file specified in your config and encrypted with the specified passphrase.
+3. Run `node examples/bankLetter.js <environment> <bank> [entity]` to generate the Initialization Letter
+4. Print the letter, sign it and send it to your bank. Wait for them to activate your EBICS account.
+5. Download the bank keys by running `node examples/save-bank-keys.js <environment> <bank> [entity]`
+
+If all these steps were executed successfully, you can now do all things EBICS, like fetching bank statements by running `node examples/send-sta-order.js <environment> <bank> [entity]`, or actually use this library in your custom banking applications.
 
 ## Supported Banks
+
 The client is currently tested and verified to work with the following banks:
 
-* [Credit Suisse (Schweiz) AG](https://www.credit-suisse.com/ch/en.html)
-* [Zürcher Kantonalbank](https://www.zkb.ch/en/lg/ew.html)
-* [Raiffeisen Schweiz](https://www.raiffeisen.ch/rch/de.html)
-* [BW Bank](https://www.bw-bank.de/de/home.html)
-* [Bank GPB International S.A.](https://gazprombank.lu/e-banking)
-* [Bank GPB AO](https://gazprombank.ru/)
-* [J.P. Morgan](https://www.jpmorgan.com/)
-
+-   [Credit Suisse (Schweiz) AG](https://www.credit-suisse.com/ch/en.html)
+-   [Zürcher Kantonalbank](https://www.zkb.ch/en/lg/ew.html)
+-   [Raiffeisen Schweiz](https://www.raiffeisen.ch/rch/de.html)
+-   [BW Bank](https://www.bw-bank.de/de/home.html)
+-   [Bank GPB International S.A.](https://gazprombank.lu/e-banking)
+-   [Bank GPB AO](https://gazprombank.ru/)
+-   [J.P. Morgan](https://www.jpmorgan.com/)
 
 ## Inspiration
 
 The basic concept of this library was inspired by the [EPICS](https://github.com/railslove/epics) library from the Railslove Team.
-
 
 ## Copyright
 

--- a/examples/bankLetter.js
+++ b/examples/bankLetter.js
@@ -10,7 +10,7 @@ const os = require('os');
 const config = require('./loadConfig')();
 const client = require('./getClient')(config);
 const bankName = client.bankName;
-const template = fs.readFileSync("../templates/ini_"+client.languageCode+".hbs", { encoding: 'utf8'});
+const template = fs.readFileSync("./templates/ini_"+client.languageCode+".hbs", { encoding: 'utf8'});
 const bankLetterFile = path.join("./", "bankLetter_"+client.bankShortName+"_"+client.languageCode+".html");
 
 const letter = new ebics.BankLetter({ client, bankName, template });

--- a/examples/getClient.js
+++ b/examples/getClient.js
@@ -10,6 +10,7 @@ module.exports = ({
 	userId,
 	hostId,
 	passphrase,
+	iv,
 	keyStoragePath,
 } = loadConfig()) => new Client({
 	url,
@@ -17,5 +18,6 @@ module.exports = ({
 	userId,
 	hostId,
 	passphrase,
+	iv,
 	keyStorage: fsKeysStorage(keyStoragePath),
 });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -216,26 +216,25 @@ module.exports = class Client {
 					.persist();
 
 			rock({
-					method: 'POST',
-					url: this.url,
-					body: r,
-					headers: { 'content-type': 'text/xml;charset=UTF-8' },
-				},
-				(err, res, data) => {
-					if (err) reject(err);
+				method: 'POST',
+				url: this.url,
+				body: r,
+				headers: { 'content-type': 'text/xml;charset=UTF-8' },
+			},
+			(err, res, data) => {
+				if (err) reject(err);
 
-					const ebicsResponse = response.version(version)(data.toString('utf-8'), keys);
+				const ebicsResponse = response.version(version)(data.toString('utf-8'), keys);
 
-					if (this.tracesStorage)
-						this.tracesStorage
-							.label(`RESPONSE.${order.orderDetails.OrderType}`)
-							.connect()
-							.data(ebicsResponse.toXML())
-							.persist();
+				if (this.tracesStorage)
+					this.tracesStorage
+						.label(`RESPONSE.${order.orderDetails.OrderType}`)
+						.connect()
+						.data(ebicsResponse.toXML())
+						.persist();
 
-					resolve(ebicsResponse);
-				},
-			);
+				resolve(ebicsResponse);
+			});
 		});
 	}
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -43,7 +43,8 @@ const stringifyKeys = (keys) => {
  * @property {string} partnerId - PARTNERID provided by the bank
  * @property {string} hostId - HOSTID provided by the bank
  * @property {string} userId - USERID provided by the bank
- * @property {string} passphrase - passphrase for keys encryption
+ * @property {string|Buffer} passphrase - passphrase or key for keys encryption
+ * @property {string|Buffer} iv - Initialization Vector for keys encryption
  * @property {KeyStorage} keyStorage - keyStorage implementation
  * @property {object} [tracesStorage] - traces (logs) storage implementation
  * @property {string} bankName - Full name of the bank to be used in the bank INI letters.
@@ -51,7 +52,6 @@ const stringifyKeys = (keys) => {
  * @property {string} languageCode - Language code to be used in the bank INI letters ("de", "en" and "fr" are currently supported).
  * @property {string} storageLocation - Location where to store the files that are downloaded. This can be a network share for example.
  */
-
 module.exports = class Client {
 	/**
 	 *Creates an instance of Client.
@@ -63,6 +63,7 @@ module.exports = class Client {
 		userId,
 		hostId,
 		passphrase,
+		iv,
 		keyStorage,
 		tracesStorage,
 		bankName,
@@ -88,7 +89,7 @@ module.exports = class Client {
 		this.userId = userId;
 		this.hostId = hostId;
 		this.keyStorage = keyStorage;
-		this.keyEncryptor = defaultKeyEncryptor({ passphrase });
+		this.keyEncryptor = defaultKeyEncryptor({ passphrase, iv });
 		this.tracesStorage = tracesStorage || null;
 		this.bankName = bankName || 'Dummy Bank Full Name';
 		this.bankShortName = bankShortName || 'BANKSHORTCODE';
@@ -249,7 +250,6 @@ module.exports = class Client {
 	async keys() {
 		try {
 			const keysString = await this._readKeys();
-
 			return new Keys(JSON.parse(this.keyEncryptor.decrypt(keysString)));
 		} catch (err) {
 			return null;

--- a/lib/crypto/Crypto.js
+++ b/lib/crypto/Crypto.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const crypto = require('crypto');
+const NodeRSA = require('node-rsa');
 
 const BigNumber = require('./BigNumber.js');
 const mgf1 = require('./MGF1');
@@ -54,10 +55,14 @@ module.exports = class Crypto {
 	}
 
 	static privateDecrypt(key, data) {
-		return crypto.privateDecrypt({
-			key: key.toPem(),
-			padding: crypto.constants.RSA_PKCS1_PADDING,
-		}, data);
+		const keyRSA = new NodeRSA(
+			key.toPem(),
+			'pkcs1-private-pem', {
+				encryptionScheme: 'pkcs1',
+				environment: 'browser', // would use the crypto module by default, which blocks pkcs1
+			},
+		);
+		return keyRSA.decrypt(data);
 	}
 
 	static privateSign(key, data, outputEncoding = 'base64') {

--- a/lib/crypto/encryptDecrypt.js
+++ b/lib/crypto/encryptDecrypt.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const createKeyAndIv = (passphrase) => {
+	// this generates a 256-bit key and a 128-bit iv for aes-256-cbc
+	// just like nodejs's deprecated/removed crypto.createCipher would
+	const a = crypto.createHash('md5').update(passphrase).digest();
+	const b = crypto
+		.createHash('md5')
+		.update(Buffer.concat([a, Buffer.from(passphrase)]))
+		.digest();
+	const c = crypto
+		.createHash('md5')
+		.update(Buffer.concat([b, Buffer.from(passphrase)]))
+		.digest();
+	const bytes = Buffer.concat([a, b, c]);
+	const key = bytes.subarray(0, 32);
+	const iv = bytes.subarray(32, 48);
+	return { key, iv };
+};
+
+const encrypt = (data, algorithm, passphrase, iv) => {
+	let cipher;
+	if (iv) {
+		cipher = crypto.createCipheriv(algorithm, passphrase, iv);
+	} else {
+		console.warn(
+			'[Deprecation notice] No IV provided, falling back to legacy key derivation.\n'
+            + 'This will be removed in a future major release. You should encrypt your keys with a proper key and IV.',
+		);
+		if (crypto.createCipher) {
+			// nodejs < 22
+			cipher = crypto.createCipher(algorithm, passphrase);
+		} else {
+			const { key, iv: generatedIv } = createKeyAndIv(passphrase);
+			cipher = crypto.createCipheriv(algorithm, key, generatedIv);
+		}
+	}
+	const encrypted = cipher.update(data, 'utf8', 'hex') + cipher.final('hex');
+	return Buffer.from(encrypted).toString('base64');
+};
+
+const decrypt = (data, algorithm, passphrase, iv) => {
+	data = Buffer.from(data, 'base64').toString();
+	let decipher;
+	if (iv) {
+		decipher = crypto.createDecipheriv(algorithm, passphrase, iv);
+	} else {
+		console.warn(
+			'[Deprecation notice] No IV provided, falling back to legacy key derivation.\n'
+			+ 'This will be removed in a future major release. You should re-encrypt your keys with a proper key and IV.',
+		);
+		if (crypto.createDecipher) {
+			// nodejs < 22
+			decipher = crypto.createDecipher(algorithm, passphrase);
+		} else {
+			const { key, iv: generatedIv } = createKeyAndIv(passphrase);
+			decipher = crypto.createDecipheriv(algorithm, key, generatedIv);
+		}
+	}
+	const decrypted = decipher.update(data, 'hex', 'utf8') + decipher.final('utf8');
+	return decrypted;
+};
+
+module.exports = { encrypt, decrypt };

--- a/lib/keymanagers/KeysManager.js
+++ b/lib/keymanagers/KeysManager.js
@@ -1,23 +1,7 @@
 'use strict';
 
-const crypto = require('crypto');
-
+const { encrypt, decrypt } = require('../crypto/encryptDecrypt');
 const Keys = require('./Keys');
-
-const encrypt = (data, algorithm, passphrase) => {
-	const cipher = crypto.createCipher(algorithm, passphrase);
-	const encrypted = cipher.update(data, 'utf8', 'hex') + cipher.final('hex');
-
-	return Buffer.from(encrypted).toString('base64');
-};
-const decrypt = (data, algorithm, passphrase) => {
-	data = (Buffer.from(data, 'base64')).toString();
-
-	const decipher = crypto.createDecipher(algorithm, passphrase);
-	const decrypted = decipher.update(data, 'hex', 'utf8') + decipher.final('utf8');
-
-	return decrypted;
-};
 
 module.exports = (keysStorage, passphrase, algorithm = 'aes-256-cbc') => {
 	const storage = keysStorage;

--- a/lib/keymanagers/defaultKeyEncryptor.js
+++ b/lib/keymanagers/defaultKeyEncryptor.js
@@ -1,24 +1,9 @@
 'use strict';
 
-const crypto = require('crypto');
+const { encrypt, decrypt } = require('../crypto/encryptDecrypt');
 
-const encrypt = (data, algorithm, passphrase) => {
-	const cipher = crypto.createCipher(algorithm, passphrase);
-	const encrypted = cipher.update(data, 'utf8', 'hex') + cipher.final('hex');
-	return Buffer.from(encrypted).toString('base64');
-};
-const decrypt = (data, algorithm, passphrase) => {
-	data = (Buffer.from(data, 'base64')).toString();
-	const decipher = crypto.createDecipher(algorithm, passphrase);
-	const decrypted = decipher.update(data, 'hex', 'utf8') + decipher.final('utf8');
 
-	return decrypted;
-};
-
-module.exports = ({
-	passphrase,
-	algorithm = 'aes-256-cbc',
-}) => ({
-	encrypt: data => encrypt(data, algorithm, passphrase),
+module.exports = ({ passphrase, iv, algorithm = 'aes-256-cbc' }) => ({
+	encrypt: data => encrypt(data, algorithm, passphrase, iv),
 	decrypt: data => decrypt(data, algorithm, passphrase),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"handlebars": "^4.7.8",
 				"js2xmlparser": "^5.0.0",
 				"node-forge": "^1.3.1",
+				"node-rsa": "^1.1.1",
 				"rock-req": "^5.1.3",
 				"uuid": "^9.0.1",
 				"xml-crypto": "^6.0.0",
@@ -767,7 +768,6 @@
 		},
 		"node_modules/asn1": {
 			"version": "0.2.4",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": "~2.1.0"
@@ -3498,6 +3498,14 @@
 			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
 			"dev": true
 		},
+		"node_modules/node-rsa": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
+			"integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
+			"dependencies": {
+				"asn1": "^0.2.4"
+			}
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"dev": true,
@@ -4218,7 +4226,6 @@
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ebics-client",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ebics-client",
-			"version": "4.1.0",
+			"version": "4.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@xmldom/xmldom": "^0.8.10",
@@ -25,9 +25,9 @@
 				"eslint": "^6.7.2",
 				"eslint-config-ecollect-base": "^0.1.2",
 				"eslint-plugin-import": "^2.28.1",
-				"libxmljs": "^1.0.10",
 				"mocha": "^10.2.0",
-				"nyc": "^15.1.0"
+				"nyc": "^15.1.0",
+				"xmllint-wasm": "^4.0.2"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -490,40 +490,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@mapbox/node-pre-gyp": {
-			"version": "1.0.9",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"detect-libc": "^2.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"make-dir": "^3.1.0",
-				"node-fetch": "^2.6.7",
-				"nopt": "^5.0.0",
-				"npmlog": "^5.0.1",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"node-pre-gyp": "bin/node-pre-gyp"
-			}
-		},
-		"node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"dev": true,
@@ -544,11 +510,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/abbrev": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/acorn": {
 			"version": "7.4.1",
 			"dev": true,
@@ -566,33 +527,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/agent-base/node_modules/debug": {
-			"version": "4.3.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -716,27 +650,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/aproba": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/archy": {
 			"version": "1.0.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/are-we-there-yet": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
@@ -962,11 +879,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/bindings": {
-			"version": "1.3.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"dev": true,
@@ -1186,14 +1098,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/chownr": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
 			"dev": true,
@@ -1265,14 +1169,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/color-support": {
-			"version": "1.1.3",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"color-support": "bin.js"
-			}
-		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"dev": true,
@@ -1306,11 +1202,6 @@
 			"version": "1.0.9",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/console-control-strings": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/convert-source-map": {
 			"version": "1.7.0",
@@ -1458,19 +1349,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/delegates": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/detect-libc": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/diff": {
@@ -2241,17 +2119,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"dev": true,
@@ -2302,46 +2169,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/gauge": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.2",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.1",
-				"object-assign": "^4.1.1",
-				"signal-exit": "^3.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/gauge/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/gauge/node_modules/string-width": {
-			"version": "4.2.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/gensync": {
@@ -2594,11 +2421,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-unicode": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/hasha": {
 			"version": "5.2.2",
 			"dev": true,
@@ -2639,34 +2461,6 @@
 			"engines": {
 				"node": ">=0.8",
 				"npm": ">=1.3.7"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/https-proxy-agent/node_modules/debug": {
-			"version": "4.3.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -3344,21 +3138,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/libxmljs": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-1.0.11.tgz",
-			"integrity": "sha512-ChqXkhZuvhbjariwPakKs/h+dF5Pe7j+QJ/PmTidzx7mDiFa5chhy7806PQiO+VnBJZ5mVLVq4Dk+W7fZP6luw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"@mapbox/node-pre-gyp": "^1.0.9",
-				"bindings": "~1.3.0",
-				"nan": "^2.17.0"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"dev": true,
@@ -3519,29 +3298,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minipass": {
-			"version": "3.3.4",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minizlib": {
-			"version": "2.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
 			"dev": true,
@@ -3674,11 +3430,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/nan": {
-			"version": "2.18.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/nanoid": {
 			"version": "3.3.3",
 			"dev": true,
@@ -3747,37 +3498,12 @@
 			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
 			"dev": true
 		},
-		"node_modules/nopt": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"abbrev": "1"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npmlog": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"are-we-there-yet": "^2.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^3.0.0",
-				"set-blocking": "^2.0.0"
 			}
 		},
 		"node_modules/nyc": {
@@ -3967,14 +3693,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -4287,19 +4005,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "3.6.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/readdirp": {
@@ -4663,46 +4368,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
-		"node_modules/string-width": {
-			"version": "2.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-			"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/string.prototype.trim": {
 			"version": "1.2.8",
 			"dev": true,
@@ -4857,43 +4522,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/tar/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/test-exclude": {
@@ -5169,11 +4797,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/uuid": {
 			"version": "9.0.1",
 			"funding": [
@@ -5267,14 +4890,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/wide-align": {
-			"version": "1.1.3",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^1.0.2 || 2"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -5381,6 +4996,15 @@
 		"node_modules/xmlcreate": {
 			"version": "2.0.4",
 			"license": "Apache-2.0"
+		},
+		"node_modules/xmllint-wasm": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xmllint-wasm/-/xmllint-wasm-4.0.2.tgz",
+			"integrity": "sha512-tJxQzA9krv9gaQxYFJ/NVrpLf/wpWYPKjweCLMNbjooBTsW7/O26pyc3Pd0Lp0oTLUMFir/MEX3ybY/hhRjIpw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.4.0"
+			}
 		},
 		"node_modules/xpath": {
 			"version": "0.0.32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "ebics-client",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ebics-client",
-			"version": "4.0.0",
-			"license": "GPL-3.0-only",
+			"version": "4.1.0",
+			"license": "MIT",
 			"dependencies": {
 				"@xmldom/xmldom": "^0.8.10",
 				"handlebars": "^4.7.8",
@@ -15,7 +15,7 @@
 				"node-forge": "^1.3.1",
 				"rock-req": "^5.1.3",
 				"uuid": "^9.0.1",
-				"xml-crypto": "^4.0.1",
+				"xml-crypto": "^6.0.0",
 				"xpath": "0.0.32"
 			},
 			"devDependencies": {
@@ -529,6 +529,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@xmldom/is-dom-node": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+			"integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
 		"node_modules/@xmldom/xmldom": {
 			"version": "0.8.10",
 			"license": "MIT",
@@ -969,11 +977,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2026,9 +2035,10 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -2940,8 +2950,9 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -3334,10 +3345,11 @@
 			}
 		},
 		"node_modules/libxmljs": {
-			"version": "1.0.10",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-1.0.11.tgz",
+			"integrity": "sha512-ChqXkhZuvhbjariwPakKs/h+dF5Pe7j+QJ/PmTidzx7mDiFa5chhy7806PQiO+VnBJZ5mVLVq4Dk+W7fZP6luw==",
 			"dev": true,
 			"hasInstallScript": true,
-			"license": "MIT",
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^1.0.9",
 				"bindings": "~1.3.0",
@@ -4848,19 +4860,29 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "6.1.11",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
+				"minipass": "^5.0.0",
 				"minizlib": "^2.1.1",
 				"mkdirp": "^1.0.3",
 				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">=10"
+			}
+		},
+		"node_modules/tar/node_modules/minipass": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tar/node_modules/mkdirp": {
@@ -4918,8 +4940,9 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -5336,14 +5359,16 @@
 			}
 		},
 		"node_modules/xml-crypto": {
-			"version": "4.1.0",
-			"license": "MIT",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
+			"integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
 			"dependencies": {
+				"@xmldom/is-dom-node": "^1.0.1",
 				"@xmldom/xmldom": "^0.8.10",
-				"xpath": "0.0.33"
+				"xpath": "^0.0.33"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			}
 		},
 		"node_modules/xml-crypto/node_modules/xpath": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,15 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.13",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.22.13",
-				"chalk": "^2.4.2"
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -235,16 +238,19 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -257,33 +263,28 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.13.10",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+			"integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.22.20",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+			"integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.27.0"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -292,14 +293,15 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+			"integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -343,14 +345,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+			"integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -558,7 +560,9 @@
 			}
 		},
 		"node_modules/ansi-colors": {
-			"version": "4.1.1",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1240,7 +1244,9 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1352,7 +1358,9 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "5.0.0",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -1682,7 +1690,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/cross-spawn": {
-			"version": "6.0.5",
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3032,6 +3042,8 @@
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3310,31 +3322,32 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "10.2.0",
+			"version": "10.8.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+			"integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.3",
-				"debug": "4.3.4",
-				"diff": "5.0.0",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.2.0",
-				"he": "1.2.0",
-				"js-yaml": "4.1.0",
-				"log-symbols": "4.1.0",
-				"minimatch": "5.0.1",
-				"ms": "2.1.3",
-				"nanoid": "3.3.3",
-				"serialize-javascript": "6.0.0",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "8.1.1",
-				"workerpool": "6.2.1",
-				"yargs": "16.2.0",
-				"yargs-parser": "20.2.4",
-				"yargs-unparser": "2.0.0"
+				"ansi-colors": "^4.1.3",
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^3.5.3",
+				"debug": "^4.3.5",
+				"diff": "^5.2.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^8.1.0",
+				"he": "^1.2.0",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^5.1.6",
+				"ms": "^2.1.3",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^6.5.1",
+				"yargs": "^16.2.0",
+				"yargs-parser": "^20.2.9",
+				"yargs-unparser": "^2.0.0"
 			},
 			"bin": {
 				"_mocha": "bin/_mocha",
@@ -3342,10 +3355,6 @@
 			},
 			"engines": {
 				"node": ">= 14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mochajs"
 			}
 		},
 		"node_modules/mocha/node_modules/argparse": {
@@ -3355,6 +3364,8 @@
 		},
 		"node_modules/mocha/node_modules/brace-expansion": {
 			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3362,11 +3373,13 @@
 			}
 		},
 		"node_modules/mocha/node_modules/debug": {
-			"version": "4.3.4",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -3377,11 +3390,6 @@
 				}
 			}
 		},
-		"node_modules/mocha/node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/mocha/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"dev": true,
@@ -3391,6 +3399,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mocha/node_modules/js-yaml": {
@@ -3405,7 +3434,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/minimatch": {
-			"version": "5.0.1",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3429,17 +3460,6 @@
 			"version": "0.0.8",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/nanoid": {
-			"version": "3.3.3",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -4009,6 +4029,8 @@
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4237,7 +4259,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.0",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4563,14 +4587,6 @@
 			},
 			"engines": {
 				"node": ">=0.6.0"
-			}
-		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -4912,7 +4928,9 @@
 			"license": "MIT"
 		},
 		"node_modules/workerpool": {
-			"version": "6.2.1",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -4981,9 +4999,10 @@
 			}
 		},
 		"node_modules/xml-crypto": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
-			"integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.1.tgz",
+			"integrity": "sha512-v05aU7NS03z4jlZ0iZGRFeZsuKO1UfEbbYiaeRMiATBFs6Jq9+wqKquEMTn4UTrYZ9iGD8yz3KT4L9o2iF682w==",
+			"license": "MIT",
 			"dependencies": {
 				"@xmldom/is-dom-node": "^1.0.1",
 				"@xmldom/xmldom": "^0.8.10",
@@ -5048,7 +5067,9 @@
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "20.2.4",
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
 	],
 	"scripts": {
 		"lint": "eslint .",
-		"test": "nyc node --security-revert=CVE-2023-46809 ./node_modules/.bin/mocha test/**/*.js",
+		"test": "npm run test:node$(node -v | cut -d '.' -f 1 | cut -c 2-)",
+		"test:node22": "nyc node ./node_modules/.bin/mocha test/**/*.js",
+		"test:node20": "nyc node --security-revert=CVE-2023-46809 ./node_modules/.bin/mocha test/**/*.js",
+		"test:node18": "nyc node --security-revert=CVE-2023-46809 ./node_modules/.bin/mocha test/**/*.js",
 		"coverage": "nyc report --reporter=text-lcov | coveralls",
 		"version": "auto-changelog -p -t changelog-template.hbs && git add CHANGELOG.md"
 	},

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	],
 	"scripts": {
 		"lint": "eslint .",
-		"test": "nyc mocha test/**/*.js",
+		"test": "nyc node --security-revert=CVE-2023-46809 ./node_modules/.bin/mocha test/**/*.js",
 		"coverage": "nyc report --reporter=text-lcov | coveralls",
 		"version": "auto-changelog -p -t changelog-template.hbs && git add CHANGELOG.md"
 	},

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"node-forge": "^1.3.1",
 		"rock-req": "^5.1.3",
 		"uuid": "^9.0.1",
-		"xml-crypto": "^4.0.1",
+		"xml-crypto": "^6.0.0",
 		"xpath": "0.0.32"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"handlebars": "^4.7.8",
 		"js2xmlparser": "^5.0.0",
 		"node-forge": "^1.3.1",
+		"node-rsa": "^1.1.1",
 		"rock-req": "^5.1.3",
 		"uuid": "^9.0.1",
 		"xml-crypto": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
 		"eslint": "^6.7.2",
 		"eslint-config-ecollect-base": "^0.1.2",
 		"eslint-plugin-import": "^2.28.1",
-		"libxmljs": "^1.0.10",
 		"mocha": "^10.2.0",
-		"nyc": "^15.1.0"
+		"nyc": "^15.1.0",
+		"xmllint-wasm": "^4.0.2"
 	}
 }


### PR DESCRIPTION
I'm currently using a fork of this library, so I guess it's time to contribute my changes back to upstream. :upside_down_face: 

* `createCipher` and `createDecipher` are deprecated in Node.js and cause warnings. ~This resolves the warnings without changing the logic.~ Changing this to the more secure `createCipheriv` and `createDecipheriv` would require storing IVs and break existing key files, so I kept it as is for now (it was changed to a wrong implementation in an earlier version of this PR)
* xml-crypto 4.x has a critical vulnerability, so I updated to 6.x. This in turn requires Node.js 16 or later, so I bumped the minimum version of this library in the readme (given that the oldest still supported Node.js version is Node.js 18, I hope that this is fine; if we update to Node.js >= 21, we could even get rid of rock-req and use the built-in `fetch` instead).
* The initialization process involved a lot of trial-and-error for me. I extended the README to include my findings, and help new users setup their EBICS accounts.